### PR TITLE
Added include for macOS types

### DIFF
--- a/unif_types.h
+++ b/unif_types.h
@@ -40,6 +40,8 @@ extern "C"{
 	#endif
 #elif defined (__HAIKU__)
 	#include <stdint.h>
+#elif defined (__APPLE__) && defined (__MACH__)
+	#include <stdint.h>
 #elif defined (__linux__) || defined(__linux) || defined(__gnu_linux__)
 	#include <stdint.h>
 #elif defined(SunOS)


### PR DESCRIPTION
The data types used in this code require stdint.h to be included on macOS.  This adds a test and an include for that.